### PR TITLE
WIP: Add ipam

### DIFF
--- a/pkg/apis/cluster/v1alpha1/cluster_types.go
+++ b/pkg/apis/cluster/v1alpha1/cluster_types.go
@@ -69,6 +69,9 @@ type ClusterNetworkingConfig struct {
 
 	// Domain name for services.
 	ServiceDomain string `json:"serviceDomain"`
+
+	// ReservedAddresses for nodes. Empty list implies using DHCP.
+	ReservedAddresses []Address `json:"reserved_addresses"`
 }
 
 // NetworkRanges represents ranges of network addresses.
@@ -99,6 +102,28 @@ type ClusterStatus struct {
 	// own versioned API types that should be
 	// serialized/deserialized from this field.
 	ProviderStatus *runtime.RawExtension `json:"providerStatus"`
+
+	// AddressStatus is the IPAM status
+	AddressStatus AddressStatus `json:"address_status"`
+}
+
+// AddressStatus is the IPAM status
+type AddressStatus struct {
+	// AllocableAddresses is the addresses that are free to use
+	AllocableAddresses []Address `json:"allocable_addresses"`
+
+	// UsedAddress are the addresses that are already assigned to machine
+	UsedAddresses []Address `json:"used_addresses"`
+}
+
+// Address represents an address allocated to a machine
+type Address struct {
+	// IP represents an IP address
+	IP string `json:"ip"`
+
+	// Hostname is the hostname of the machine
+	// +optional
+	Hostname string `json:"hostname"`
 }
 
 // APIEndpoint represents a reachable Kubernetes API endpoint.

--- a/pkg/ipam/address_pool.go
+++ b/pkg/ipam/address_pool.go
@@ -1,0 +1,14 @@
+package ipam
+
+type addressPool struct {
+	storage Storage
+	key     string
+}
+
+func (p *addressPool) Allocate() (*Address, error) {
+	return p.storage.Allocate(p.key)
+}
+
+func (p *addressPool) Release(address *Address) error {
+	return p.storage.Release(p.key, address.Key())
+}

--- a/pkg/ipam/example_test.go
+++ b/pkg/ipam/example_test.go
@@ -1,0 +1,32 @@
+package ipam_test
+
+import (
+	"fmt"
+
+	"k8s.io/cluster-api/pkg/ipam"
+)
+
+func ExampleIPManager() {
+	storage := ipam.NewInMemStorage()
+	im := ipam.NewIPManager(storage)
+	im.Add("cluster-1", []ipam.Address{
+		{
+			IP:       "1.1.1.1",
+			Hostname: "1-1-1-1.local",
+			DNS:      []string{"8.8.8.8"},
+		},
+	})
+
+	address, err := im.AddressPool("cluster-1").Allocate()
+	fmt.Println(address, err)
+
+	err = im.AddressPool("cluster-1").Release(address)
+	fmt.Println(err)
+
+	err = im.RemoveAll("cluster-1")
+	fmt.Println(err)
+
+	// Output: &{1.1.1.1 1-1-1-1.local [8.8.8.8]} <nil>
+	// <nil>
+	// <nil>
+}

--- a/pkg/ipam/inmem_storage.go
+++ b/pkg/ipam/inmem_storage.go
@@ -1,0 +1,97 @@
+package ipam
+
+import "sync"
+
+// inMemStorage is an in memory implementation of interface Storage
+type inMemStorage struct {
+	// mapping of cluster->ip->address
+	free, used map[string]map[string]Address
+
+	sync.Mutex
+}
+
+func NewInMemStorage() Storage {
+	return &inMemStorage{
+		free: make(map[string]map[string]Address),
+		used: make(map[string]map[string]Address),
+	}
+}
+
+func (s *inMemStorage) Add(key string, addresses []Address) error {
+	s.Lock()
+	defer s.Unlock()
+
+	if _, ok := s.free[key]; !ok {
+		s.free[key] = make(map[string]Address)
+		s.used[key] = make(map[string]Address)
+	}
+
+	free, used := s.free[key], s.used[key]
+	for _, address := range addresses {
+		akey := address.Key()
+		_, ok1 := free[akey]
+		_, ok2 := used[akey]
+		if !ok1 && !ok2 {
+			free[akey] = address
+		}
+	}
+
+	return nil
+}
+
+func (s *inMemStorage) Remove(key string) error {
+	s.Lock()
+	defer s.Unlock()
+
+	delete(s.free, key)
+	delete(s.used, key)
+
+	return nil
+}
+
+func (s *inMemStorage) Allocate(key string) (*Address, error) {
+	s.Lock()
+	defer s.Unlock()
+
+	if _, ok := s.free[key]; !ok {
+		return nil, ErrKeyNotFound
+	}
+
+	free := s.free[key]
+	used := s.used[key]
+
+	if len(free) == 0 {
+		return nil, ErrNotEnoughAddress
+	}
+
+	var address *Address
+	for ip, a := range free {
+		used[ip] = a
+		delete(free, ip)
+		address = &a
+		break
+	}
+
+	return address, nil
+}
+
+func (s *inMemStorage) Release(key, addressKey string) error {
+	s.Lock()
+	defer s.Unlock()
+
+	if _, ok := s.used[key]; !ok {
+		return ErrKeyNotFound
+	}
+
+	free := s.free[key]
+	used := s.used[key]
+
+	if _, ok := used[addressKey]; !ok {
+		return ErrReleaseUnallocatedIP
+	}
+
+	free[addressKey] = used[addressKey]
+	delete(used, addressKey)
+
+	return nil
+}

--- a/pkg/ipam/inmem_storage_test.go
+++ b/pkg/ipam/inmem_storage_test.go
@@ -1,0 +1,129 @@
+package ipam
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
+
+var testAddresses = []Address{
+	{
+		IP:       "1.1.1.1",
+		Hostname: "1-1-1-1.local",
+		DNS:      []string{"8.8.8.8"},
+	},
+	{
+		IP:       "1.1.1.2",
+		Hostname: "1-1-1-2.local",
+		DNS:      []string{"8.8.8.8"},
+	},
+	{
+		IP:       "1.1.1.3",
+		Hostname: "1-1-1-3.local",
+		DNS:      []string{"8.8.8.8"},
+	},
+}
+
+func TestInMemStorageAllocate(t *testing.T) {
+	s := NewInMemStorage()
+
+	s.Add("cluster-1", testAddresses)
+
+	var got []string
+	for i := 0; i < len(testAddresses); i++ {
+		a, err := s.Allocate("cluster-1")
+		if err != nil {
+			t.Fatalf("unexpected error from t.Allocate(cluster): %q", err)
+		}
+		got = append(got, a.IP)
+	}
+
+	sort.Strings(got)
+	expected := []string{"1.1.1.1", "1.1.1.2", "1.1.1.3"}
+	if !reflect.DeepEqual(got, expected) {
+		t.Fatalf("expected Allocate results: %s; got %s", expected, got)
+	}
+}
+
+func TestInMemStorageRemove(t *testing.T) {
+	s := NewInMemStorage()
+
+	s.Add("cluster-1", testAddresses)
+
+	for i := 0; i < len(testAddresses); i++ {
+		_, err := s.Allocate("cluster-1")
+		if err != nil {
+			t.Fatalf("unexpected error from t.Allocate(cluster): %q", err)
+		}
+	}
+
+	err := s.Remove("cluster-1")
+	if err != nil {
+		t.Fatalf("unexpected error from t.Remove(cluster): %q", err)
+	}
+
+	_, err = s.Allocate("cluster-1")
+	if err != ErrKeyNotFound {
+		t.Fatalf("expect error %q, got %q", ErrKeyNotFound, err)
+	}
+}
+
+func TestInMemStorageOverAllocate(t *testing.T) {
+	s := NewInMemStorage()
+
+	s.Add("cluster-1", testAddresses)
+
+	for i := 0; i < len(testAddresses); i++ {
+		_, err := s.Allocate("cluster-1")
+		if err != nil {
+			t.Fatalf("unexpected error from t.Allocate(cluster): %q", err)
+		}
+	}
+
+	_, err := s.Allocate("cluster-1")
+	if err != ErrNotEnoughAddress {
+		t.Fatalf("expect error %q, got %q", ErrNotEnoughAddress, err)
+	}
+}
+
+func TestInMemStorageRelease(t *testing.T) {
+	s := NewInMemStorage()
+
+	s.Add("cluster-1", testAddresses)
+
+	var addresses []Address
+	for i := 0; i < len(testAddresses); i++ {
+		a, err := s.Allocate("cluster-1")
+		if err != nil {
+			t.Fatalf("unexpected error from t.Allocate(cluster): %q", err)
+		}
+		addresses = append(addresses, *a)
+	}
+
+	for _, address := range addresses {
+		err := s.Release("cluster-1", address.Key())
+		if err != nil {
+			t.Fatalf("unexpected error from t.Release(cluster, ip): %q", err)
+		}
+	}
+}
+
+func TestInMemStorageReleaseUnAllocated(t *testing.T) {
+	s := NewInMemStorage()
+
+	s.Add("cluster-1", testAddresses)
+
+	var addresses []Address
+	for i := 0; i < len(testAddresses); i++ {
+		a, err := s.Allocate("cluster-1")
+		if err != nil {
+			t.Fatalf("unexpected error from t.Allocate(cluster): %q", err)
+		}
+		addresses = append(addresses, *a)
+	}
+
+	err := s.Release("cluster-1", "9.9.9.9")
+	if err != ErrReleaseUnallocatedIP {
+		t.Fatalf("expect error %q, got %q", ErrReleaseUnallocatedIP, err)
+	}
+}

--- a/pkg/ipam/interface.go
+++ b/pkg/ipam/interface.go
@@ -1,0 +1,112 @@
+package ipam
+
+import (
+	"errors"
+	"path/filepath"
+)
+
+var (
+	// ErrKeyNotFound ..
+	ErrKeyNotFound = errors.New("ipam: key not found")
+
+	// ErrAddressNotFound
+	ErrAddressNotFound = errors.New("ipam: address not found")
+
+	// ErrEmptyAdressPool
+	ErrEmptyAddressPool = errors.New("ipam: empty address pool")
+
+	// ErrNotEnoughAddress
+	ErrNotEnoughAddress = errors.New("ipam: no addresses can be allocated")
+
+	// ErrReleaseUnallocatedIP
+	ErrReleaseUnallocatedIP = errors.New("ipam: cannot release an ip that is not allocated by this pool")
+)
+
+// GlobalCluster is used when there is no address pool per cluster, so all
+// clusters use addresses from this pool.
+const GlobalCluster = ""
+
+// IPManager manages IP addresses by reserving and allocating IP address in a per-cluster
+// address pool.
+type IPManager interface {
+	// Add adds addresses into an address pool identified by cluster name.
+	// If the address pool doesn't exist, create a new one.
+	Add(clusterName string, addresses []Address) error
+
+	// Remove removes address from an address pool identified by cluster name.
+	// TODO: For IP managements after cluster is created. maybe not needed.
+	Remove(clusterName string, addresses []Address) error
+
+	// RemoveAll remove an address pool identified by cluster name.
+	RemoveAll(clusterName string) error
+
+	// AddressPool returns an address pool.
+	AddressPool(clusterName string) AddressPool
+}
+
+// AddressPool represents an IP address pool to allocate IP/Hostname
+// and to release it.
+type AddressPool interface {
+	// Allocate allocates an address from the pool
+	Allocate() (*Address, error)
+
+	// Release releases the address to the pool
+	Release(address *Address) error
+}
+
+// Storage is the abstraction of how ipam persist the free/used addresses.
+type Storage interface {
+	// Add key
+	Add(key string, addresses []Address) error
+
+	// Remove key
+	Remove(key string) error
+
+	// Allocate allocates one address from
+	Allocate(key string) (*Address, error)
+
+	// Release
+	Release(key string, addressKey string) error
+}
+
+// Snapshot is the snapshot of storage which contains all the records.
+type Snapshot map[string][2][]Address
+
+// ExtraStorage provide extra functionality on storage to take a snapshot
+// of all records and recover from it. It is useful when you want to migrate
+// between different storage. e.g. from local storage to an etcd cluster.
+type ExtraStorage interface {
+	Snapshot() (Snapshot, error)
+	Recover(Snapshot) error
+
+	Storage
+}
+
+// Address is the IP address and the related network configuration.
+type Address struct {
+	// IP is an IP address (IPv6 okay?)
+	IP string
+
+	// Hostname is the hostname
+	// +optional
+	Hostname string
+
+	// DNS is the DNS servers for DNS lookup
+	// +optional
+	DNS []string
+}
+
+// Key returns address key to be saved
+func (a *Address) Key() string {
+	return a.IP
+}
+
+// TODO: move the following to other files
+
+// PathKey the the function to generate a key for key/value store
+func PathKey(base string, address *Address) string {
+	return filepath.Join(base, address.Key())
+}
+
+// KeyFunc generates key from Address object
+type KeyFunc func(base string, address *Address) string

--- a/pkg/ipam/ip_manager.go
+++ b/pkg/ipam/ip_manager.go
@@ -1,0 +1,27 @@
+package ipam
+
+import "errors"
+
+type ipManager struct {
+	storage Storage
+}
+
+func NewIPManager(storage Storage) IPManager {
+	return &ipManager{storage}
+}
+
+func (m *ipManager) Add(clusterName string, addresses []Address) error {
+	return m.storage.Add(clusterName, addresses)
+}
+
+func (m *ipManager) Remove(clusterName string, addresses []Address) error {
+	return errors.New("not implemented yet")
+}
+
+func (m *ipManager) RemoveAll(clusterName string) error {
+	return m.storage.Remove(clusterName)
+}
+
+func (m *ipManager) AddressPool(clusterName string) AddressPool {
+	return &addressPool{m.storage, clusterName}
+}


### PR DESCRIPTION
Just a quick run to make sure the direction is correct. 

What it has:
- IPManager that can allocate/release per-cluster addresses.
- Storage interface for persistence and a simple in-mem implementation.

TODOs:
- etcd implementation of Storage (or apiserver if direct talk to etcd isn't allowed)
- new cluster api for ipam if above is decided. decision needs to made where it goes to cluster or a new kind of object.
- grpc service necessary? 
- Storage migration to support the case of root cluster ip allocation happens before etcd cluster even exists. we can save it locally then migrate to etcd. 
- ... 

 